### PR TITLE
Gestione dell'aggiornamento della bracket alla conclusione di uno scontro

### DIFF
--- a/src/helpers/bracket_utils.ts
+++ b/src/helpers/bracket_utils.ts
@@ -88,7 +88,7 @@ async function propagateLoserRecovered (bracket: BracketT, round_idx: number, id
     match.loser_recovered = true;
     await match.save();
     const players = [match.white_athlete, match.red_athlete];
-    const winner_idx = players.findIndex(player => player === match.winner_athlete);
+    const winner_idx = players.findIndex(player => player && player.equals(match.winner_athlete));
     if (winner_idx === -1) {
       throw Error('winner_idx not found while propagating recovered');
     }

--- a/src/helpers/bracket_utils.ts
+++ b/src/helpers/bracket_utils.ts
@@ -144,6 +144,8 @@ export async function calculateVictory (bracket: BracketT, round_idx: number, id
       next_match.red_athlete = match.winner_athlete;
     }
 
+    await next_match.save();
+
     bracket[round_idx + 1][next_match_idx] = next_match;
   }
 

--- a/src/routers/ageclass_router.ts
+++ b/src/routers/ageclass_router.ts
@@ -108,13 +108,11 @@ async function closeAgeClass(
     tournament.winners_bracket = await Promise.all(
       main_bracket.map(async (round_data) => {
         return await Promise.all(
-          round_data.map(async (match_data) => {
-            if (match_data === null) {
+          round_data.map(async (match) => {
+            if (match === null) {
               return null;
             }
-            const match = new Match(match_data);
             await match.save();
-            match_data._id = match._id;
             return match._id;
           })
         );

--- a/src/routers/match_router.ts
+++ b/src/routers/match_router.ts
@@ -1,10 +1,12 @@
 import express = require('express');
-import { Match } from '../schemas/Match';
+import { Match, MatchInterface } from '../schemas/Match';
 import { Athlete } from '../schemas/Athlete';
 import { AgeClass } from '../schemas/AgeClass';
 import { success, error, fail } from '../controllers/base_controller';
-import { Types } from 'mongoose';
+import { Document, Types } from 'mongoose';
 import { Category } from '../schemas/Category';
+import { Tournament } from '../schemas/Tournament';
+import { calculateVictory } from '../helpers/bracket_utils';
 /* import { Tournament } from '../schemas/Tournament'; */
 /** api for matches */
 export const match_router = express.Router();
@@ -21,16 +23,24 @@ match_router.get('/:match_id', async (req, res) => {
     /* final way should use the tournament id */
     /* const tournament = await Tournament.findById(match.tournament);
     const category = await Category.findById(tournament.category); */
-    const athlete = await Athlete.findById(match.white_athlete._id);
-    const category = await Category.findById(athlete.category);
+    const tournament = await Tournament.findById(match.tournament)
+      .populate({
+        path: 'category',
+        populate: {
+          path: 'age_class'
+        }
+      });
+    const category = await Category.findById(tournament.category);
     const age_class = await AgeClass.findById(category.age_class);
     const match_data = {
       ...match.toObject(),
+      // TODO should this api return the age class params and the category_name?
       params: age_class.params,
       category_name: `${age_class.name} U${category.max_weight} ${category.gender}`,
     };
     success(res, match_data);
   } catch (e) {
+    console.error({ e });
     error(res, e.message);
   }
 });
@@ -39,6 +49,11 @@ match_router.post('/:match_id', async (req, res) => {
   try {
     const match_id = req.params.match_id;
     const match = await Match.findById(match_id);
+    const tournament = await Tournament.findById(match.tournament)
+      .populate({
+        path: 'winners_bracket',
+        model: 'Match'
+      });
     if (!match) return fail(res, 'Match not found', 404);
     const body: {
       winner_athlete: string;
@@ -59,11 +74,41 @@ match_router.post('/:match_id', async (req, res) => {
     if (body.match_scores) match.match_scores = body.match_scores;
     if (body.winner_athlete && Athlete.exists({ _id: body.winner_athlete })) {
       match.winner_athlete = new Types.ObjectId(body.winner_athlete);
-      // Girardi
+      await match.save();
+      // update the bracket
+      // find the match within the winners bracket
+      const bracket = tournament.winners_bracket as (MatchInterface & Document)[][];
+      const pos_info = findMatch(bracket, match);
+      if (pos_info === null) {
+        return error(res, 'Incontro non trovato nella bracket');
+      }
+      const [round_idx, idx] = pos_info;
+      bracket[round_idx][idx] = match;
+      tournament.winners_bracket = (await calculateVictory(bracket, round_idx, idx)).map(round => {
+        return round.map(match => {
+          return match?._id ?? null;
+        });
+      });
+      await tournament.save();
     }
     await match.save();
     success(res, match);
   } catch (e) {
+    console.error({ e });
     error(res, e.message);
   }
 });
+
+function findMatch(bracket: MatchInterface[][], match: MatchInterface): [number, number] | null {
+  for (let round_idx = 0; round_idx < bracket.length; round_idx++) {
+    const round = bracket[round_idx];
+    for (let idx = 0; idx < round.length; idx++) {
+      const other_match = round[idx];
+      if (other_match && match._id.equals(other_match._id)) {
+        return [round_idx, idx];
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/schemas/Match.ts
+++ b/src/schemas/Match.ts
@@ -1,13 +1,15 @@
 import { model, Schema, SchemaTypes, Types } from 'mongoose';
+import { TournamentInterface } from './Tournament';
 export interface MatchInterface {
   _id?: Types.ObjectId;
   white_athlete: Types.ObjectId;
   red_athlete: Types.ObjectId;
   winner_athlete: Types.ObjectId;
-  tournament: Types.ObjectId;
+  tournament: Types.ObjectId | TournamentInterface;
   is_started: boolean;
   is_over: boolean;
   match_type: number;
+  loser_recovered: boolean;
   match_scores: {
     final_time: number;
     white_ippon: number;
@@ -39,6 +41,7 @@ const match_schema = new Schema<MatchInterface>({
   is_started: Boolean,
   is_over: Boolean,
   match_type: Number,
+  loser_recovered: Boolean,
   match_scores: {
     final_time: Number,
     white_ippon: Number,

--- a/src/schemas/Tournament.ts
+++ b/src/schemas/Tournament.ts
@@ -1,4 +1,5 @@
 import { model, Schema, SchemaTypes, Types } from 'mongoose';
+import { MatchInterface } from './Match';
 
 export interface TournamentInterface {
   _id: Types.ObjectId;
@@ -7,7 +8,7 @@ export interface TournamentInterface {
   tatami_number: number;
   finished: boolean;
   athletes: Types.ObjectId[];
-  winners_bracket: Types.ObjectId[][];
+  winners_bracket: (Types.ObjectId | MatchInterface)[][];
   recovered_bracket_1: Types.ObjectId[][];
   recovered_bracket_2: Types.ObjectId[][];
 }


### PR DESCRIPTION
Questa pull request aggiunge la possiblità di gestire l'aggiornamento della bracket una volta concluso uno scontro, esso genera i nuovi match tra gli sfidanti che hanno vinto e segna i recuperati in caso dell'arrivo ai quarti di finale.